### PR TITLE
Add ability to say "Create summary for this document" without selecting the whole document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ data.json
 
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store
+/.vs

--- a/src/modules/WidgetExtension.ts
+++ b/src/modules/WidgetExtension.ts
@@ -389,8 +389,12 @@ class FloatingWidget extends WidgetType {
 			return;
 		}
 
-		// Grab the selected text from the stored selection info
-		const selectedText = this.selectionInfo?.text ?? "";
+		// Grab the selected text from the stored selection info.
+		// If nothing was selected, use the entire document as context.
+		let selectedText = this.selectionInfo?.text ?? "";
+		if (!selectedText && this.outerEditorView) {
+			selectedText = this.outerEditorView.state.doc.toString();
+		}
 
 		// Show loader
 		this.toggleLoading(true);


### PR DESCRIPTION
I love this plugin, but I have found it a bit frusterating to select the whole document if I want to do something with it (make a summary, etc).

This PR changes it so that if nothing is selected then it sends the active document

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Widget submission now intelligently provides context by automatically utilizing the entire document when no explicit text selection is made, ensuring more comprehensive processing and improved results.

* **Chores**
  * Updated repository configuration to exclude development environment directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->